### PR TITLE
Fix multi line command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export PW=mypassword
 export EMAIL=me@example.com
 
 kubectl create secret docker-registry registry-creds-secret \
-  --namespace kube-system
+  --namespace kube-system \
   --docker-username=$USERNAME \
   --docker-password=$PW \
   --docker-email=$EMAIL


### PR DESCRIPTION
If you copy/paste the example it brakes with the unescaped new line.