### PR TITLE
added IgnoreNotFound error; simplified log; README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export PW=mypassword
 export EMAIL=me@example.com
 
 kubectl create secret docker-registry registry-creds-secret \
-  --namespace kube-system
+  --namespace kube-system \
   --docker-username=$USERNAME \
   --docker-password=$PW \
   --docker-email=$EMAIL


### PR DESCRIPTION
Signed-off-by: SachinMaharana <sachin.nicky@gmail.com>

## Description
Added IgnoreNotFound error in case unable to fetch resource, thus signalling to reconcile again. Also a TODO of the project.
simplified the log which was already provided by kubebuilder. 
fixed a missing escape character  in README.md

## Which issue # does this fix? And was it approved before you worked on it?

This adds more error handling in case unable to fetch resource, as mentioned in the TODO section of README.md

Checklist:

- [ ] Fixes issue: # 
- [ ] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Followed the project  test guide. Create a `kind` cluster, add docker hub registry, and tested against `make run` to verify.
<!--- Include details of your testing environment, and the tests you ran to -->

`Kind` Cluster was used locally to test.

<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?
No Imapact. 

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
