### PR TITLE
Allow for multiple service accounts to have ImagePullSecrets applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,23 @@ Enable:
 kubectl annotate ns alex alexellis.io/registry-creds.ignore=0 --overwrite
 ```
 
+### Include additional Service Accounts
+
+Should you have additional Service Accounts within a namespace, you can allocate the pull secret by way of annotating the service account with `alexellis.io/registry-creds.include` with the value of the `ClusterPullSecret` in question.
+
+Enable:
+
+```bash
+kubectl create serviceaccount alex
+kubectl annotate serviceaccount alex alexellis.io/registry-creds.include=dockerhub
+```
+
+Disable:
+
+```bash
+kubectl annotate serviceaccount alex alexellis.io/registry-creds.include-
+```
+
 ## Testing it out
 
 Do you want to see it all in action, but don't have time to waste? You're in luck, [OpenFaaS](https://www.openfaas.com/) provides a very easy to use workflow for creating a quick Docker image that servers HTTP traffic, and that can be deployed to Kubernetes.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,8 +11,6 @@ rules:
   resources:
   - namespaces
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/controllers/clusterpullsecret_controller.go
+++ b/controllers/clusterpullsecret_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -49,14 +50,14 @@ func (r *ClusterPullSecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 
 		r.Log.Info(fmt.Sprintf("Found: %s\n", pullSecret.Name))
 
-		namespaces := &corev1.NamespaceList{}
-		r.Client.List(ctx, namespaces)
+		serviceaccounts := &corev1.ServiceAccountList{}
+		r.Client.List(ctx, serviceaccounts)
 
-		r.Log.Info(fmt.Sprintf("Found %d namespaces", len(namespaces.Items)))
+		r.Log.Info(fmt.Sprintf("Found %d ServiceAccounts", len(serviceaccounts.Items)))
 
-		for _, namespace := range namespaces.Items {
-			namespaceName := namespace.Name
-			err := r.SecretReconciler.Reconcile(pullSecret, namespaceName)
+		for _, serviceaccount := range serviceaccounts.Items {
+			namespaced := types.NamespacedName{Name: serviceaccount.Name, Namespace: serviceaccount.Namespace}
+			err := r.SecretReconciler.Reconcile(pullSecret, namespaced)
 			if err != nil {
 				r.Log.Info(fmt.Sprintf("Found error: %s", err.Error()))
 			}

--- a/controllers/namespace_watcher.go
+++ b/controllers/namespace_watcher.go
@@ -27,7 +27,7 @@ type NamespaceWatcher struct {
 	SecretReconciler *SecretReconciler
 }
 
-// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
 
 func (r *NamespaceWatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/secret_reconciler.go
+++ b/controllers/secret_reconciler.go
@@ -13,6 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -26,30 +28,26 @@ type SecretReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-const ignoreAnnotation = "alexellis.io/registry-creds.ignore"
-
-func ignoredNamespace(ns *corev1.Namespace) bool {
-	return ns.Annotations[ignoreAnnotation] == "1" || strings.ToLower(ns.Annotations[ignoreAnnotation]) == "true"
-}
-
-// Reconcile applies a number of ClusterPullSecrets to ServiceAccounts within
-// various valid namespaces. Namespaces can be ignored as required.
-func (r *SecretReconciler) Reconcile(clusterPullSecret v1.ClusterPullSecret, ns string) error {
+// Reconcile applies an PullSecret to a Namespace
+func (r *SecretReconciler) Reconcile(pullSecret v1.ClusterPullSecret, namespacedName types.NamespacedName) error {
 	ctx := context.Background()
+	const ignoreAnnotation = "alexellis.io/registry-creds.ignore"
+	const includePullSecretAnnotation = "alexellis.io/registry-creds.include"
 
-	targetNS := &corev1.Namespace{}
-	if err := r.Get(ctx, client.ObjectKey{Name: ns}, targetNS); err != nil {
-		wrappedErr := errors.Wrapf(err, "unable to fetch namespace: %s", ns)
+	targetNamespace := &corev1.Namespace{}
+	if err := r.Get(ctx, client.ObjectKey{Name: namespacedName.Namespace}, targetNamespace); err != nil {
+		wrappedErr := errors.Wrapf(err, "unable to fetch namespace for introspection:%s", namespacedName.Namespace)
 		r.Log.Info(wrappedErr.Error())
 		return wrappedErr
 	}
 
-	if ignoredNamespace(targetNS) {
-		r.Log.Info(fmt.Sprintf("ignoring namespace %s due to annotation: %s ", ns, ignoreAnnotation))
+	if targetNamespace.Annotations[ignoreAnnotation] == "1" || strings.ToLower(targetNamespace.Annotations[ignoreAnnotation]) == "true" {
+		r.Log.Info(fmt.Sprintf("ignoring serviceaccount %s due to namespace annotation %v present ", namespacedName, ignoreAnnotation))
 		return nil
 	}
 
-	r.Log.Info(fmt.Sprintf("Getting SA for: %s", ns))
+	r.Log.Info(fmt.Sprintf("Getting ServiceAccount: %v", namespacedName.Namespace))
+	secretKey := pullSecret.Name + "-registrycreds"
 
 	if clusterPullSecret.Spec.SecretRef == nil ||
 		clusterPullSecret.Spec.SecretRef.Name == "" ||
@@ -61,66 +59,78 @@ func (r *SecretReconciler) Reconcile(clusterPullSecret v1.ClusterPullSecret, ns 
 
 	pullSecret := &corev1.Secret{}
 	if err := r.Get(ctx,
-		client.ObjectKey{
-			Name:      clusterPullSecret.Spec.SecretRef.Name,
-			Namespace: clusterPullSecret.Spec.SecretRef.Namespace},
-		pullSecret); err != nil {
-		wrappedErr := errors.Wrapf(err, "unable to fetch seedSecret %s.%s", clusterPullSecret.Spec.SecretRef.Name, clusterPullSecret.Spec.SecretRef.Namespace)
-		r.Log.Info(fmt.Sprintf("%s", wrappedErr.Error()))
-		return wrappedErr
-	}
-
-	err := r.createSecret(clusterPullSecret, pullSecret, ns)
-	if err != nil {
-		r.Log.Info(err.Error())
-		return err
-	}
-
-	serviceAccountName := "default"
-	err = r.appendSecretToSA(clusterPullSecret, pullSecret, ns, serviceAccountName)
-	if err != nil {
-		r.Log.Info(err.Error())
-		return err
-	}
-
-	return nil
-}
-
-func (r *SecretReconciler) createSecret(clusterPullSecret v1.ClusterPullSecret, pullSecret *corev1.Secret, ns string) error {
-	ctx := context.Background()
-
-	secretKey := clusterPullSecret.Name + "-registrycreds"
-
-	nsSecret := &corev1.Secret{}
-	err := r.Client.Get(ctx, client.ObjectKey{Name: secretKey, Namespace: ns}, nsSecret)
-	if err != nil {
-		notFound := apierrors.IsNotFound(err)
-		if !notFound {
-			return errors.Wrap(err, "unexpected error checking for the namespaced pull secret")
+		client.ObjectKey{Name: pullSecret.Spec.SecretRef.Name, Namespace: pullSecret.Spec.SecretRef.Namespace},
+		seedSecret); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.Log.Info(fmt.Sprintf("%s", errors.Wrapf(err, "seedSecret not found %s/%s", pullSecret.Spec.SecretRef.Name, pullSecret.Spec.SecretRef.Namespace)))
+		} else {
+			r.Log.Info(fmt.Sprintf("%s", errors.Wrapf(err, "unable to fetch seedSecret: %s/%s", pullSecret.Spec.SecretRef.Name, pullSecret.Spec.SecretRef.Namespace)))
 		}
+	} else {
 
-		r.Log.Info(fmt.Sprintf("secret not found: %s.%s, %s", secretKey, ns, err.Error()))
-
-		nsSecret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretKey,
-				Namespace: ns,
-			},
-			Data: pullSecret.Data,
-			Type: corev1.SecretTypeDockerConfigJson,
-		}
-
-		err = ctrl.SetControllerReference(&clusterPullSecret, nsSecret, r.Scheme)
+		nsSecret := &corev1.Secret{}
+		err := r.Client.Get(ctx, client.ObjectKey{Name: secretKey, Namespace: targetNamespace.Name}, nsSecret)
 		if err != nil {
-			r.Log.Info(fmt.Sprintf("can't create owner reference: %s.%s, %s", secretKey, ns, err.Error()))
+			if apierrors.IsNotFound(err) {
+
+				r.Log.Info(fmt.Sprintf("secret not found: %s.%s, %s", secretKey, targetNamespace.Name, err.Error()))
+
+				nsSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretKey,
+						Namespace: targetNamespace.Name,
+					},
+					Data: seedSecret.Data,
+					Type: corev1.SecretTypeDockerConfigJson,
+				}
+				err = ctrl.SetControllerReference(&pullSecret, nsSecret, r.Scheme)
+				if err != nil {
+					r.Log.Info(fmt.Sprintf("can't create owner reference: %s.%s, %s", secretKey, targetNamespace.Name, err.Error()))
+				}
+
+				err = r.Client.Create(ctx, nsSecret)
+				if err != nil {
+					r.Log.Info(fmt.Sprintf("can't create secret: %s.%s, %s", secretKey, targetNamespace.Name, err.Error()))
+				} else {
+					r.Log.Info(fmt.Sprintf("created secret: %s.%s", secretKey, targetNamespace.Name))
+
+				}
+			} else {
+				return errors.Wrap(err, "unexpected error checking for the namespaced pull secret")
+			}
 		}
 
-		err = r.Client.Create(ctx, nsSecret)
-		if err != nil {
-			r.Log.Info(fmt.Sprintf("can't create secret: %s.%s, %s", secretKey, ns, err.Error()))
-			return err
+		sa := &corev1.ServiceAccount{}
+		err = r.Client.Get(ctx, client.ObjectKey{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, sa)
+		r.Log.Info(fmt.Sprintf("%s's Pull secrets: %v", sa.Name, sa.ImagePullSecrets))
+
+		appendSecret := false
+		if sa.Annotations[includePullSecretAnnotation] == pullSecret.Name || sa.Name == "default" {
+			if len(sa.ImagePullSecrets) == 0 {
+				appendSecret = true
+			} else {
+				found := false
+				for _, s := range sa.ImagePullSecrets {
+					if s.Name == secretKey {
+						found = true
+					}
+				}
+				appendSecret = !found
+			}
+		} else {
+			r.Log.Info(fmt.Sprintf("ignoring serviceaccount: %s, not default or annotation (%v) missing.", sa.Name, includePullSecretAnnotation))
 		}
-		r.Log.Info(fmt.Sprintf("created secret: %s.%s", secretKey, ns))
+
+		if appendSecret {
+			sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{
+				Name: secretKey,
+			})
+			err = r.Update(ctx, sa.DeepCopy())
+			if err != nil {
+				r.Log.Info(fmt.Sprintf("unable to append pull secret to service account: %s", err))
+			}
+		}
+
 	}
 
 	return nil

--- a/controllers/serviceaccount_watcher.go
+++ b/controllers/serviceaccount_watcher.go
@@ -1,0 +1,61 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	opsv1 "alexellis/registry-creds/api/v1"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceAccountWatcher watches serviceaccounts for changes
+type ServiceAccountWatcher struct {
+	client.Client
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	SecretReconciler *SecretReconciler
+}
+
+// +kubebuilder:rbac:groups=core,resources=serviceaccount,verbs=get;list;watch;create;update;patch;delete
+
+func (r *ServiceAccountWatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	_ = r.Log.WithValues("serviceaccount", req.NamespacedName)
+
+	var serviceaccount corev1.ServiceAccount
+	if err := r.Get(ctx, req.NamespacedName, &serviceaccount); err != nil {
+		r.Log.Info(fmt.Sprintf("%s", errors.Wrap(err, "unable to fetch serviceaccount")))
+	} else {
+		r.Log.Info(fmt.Sprintf("detected a change in serviceaccount: %s", req.NamespacedName))
+
+		pullSecretList := &opsv1.ClusterPullSecretList{}
+		err := r.Client.List(ctx, pullSecretList)
+		if err != nil {
+			r.Log.Info(fmt.Sprintf("unable to list ClusterPullSecrets, %s", err.Error()))
+		} else {
+			for _, pullSecret := range pullSecretList.Items {
+				err := r.SecretReconciler.Reconcile(pullSecret, req.NamespacedName)
+				if err != nil {
+					r.Log.Info(fmt.Sprintf("error reconciling serviceaccount: %s with cluster pull secret: %s", req.NamespacedName, pullSecret.Name))
+				}
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ServiceAccountWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ServiceAccount{}).
+		Complete(r)
+}

--- a/controllers/serviceaccount_watcher.go
+++ b/controllers/serviceaccount_watcher.go
@@ -25,7 +25,7 @@ type ServiceAccountWatcher struct {
 	SecretReconciler *SecretReconciler
 }
 
-// +kubebuilder:rbac:groups=core,resources=serviceaccount,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;update;patch
 
 func (r *ServiceAccountWatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -94,6 +94,16 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
+	if err = (&controllers.ServiceAccountWatcher{
+		Client:           mgr.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("ServiceAccount"),
+		Scheme:           mgr.GetScheme(),
+		SecretReconciler: secretReconciler,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create watcher", "watcher", "ServiceAccount")
+		os.Exit(1)
+	}
+
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
## Description
Allow for `ImagePullSecrets` to be applied to other Service Accounts than the default. 

## Which issue # does this fix? And was it approved before you worked on it?
No Issue, however a feature I felt worth while.

Fixes: #7

## How Has This Been Tested?
Multiple times on my own cluster.
Scenarios Tried:
- New NS = Default Changed
- New SA w/o NS Ignore Annotation = No Change
- New SA w/ NS Ignore Annotation = No Change
- New SA w/o NS ignore Annotation and SA annotation added (Invalid) = No Change
- New SA w/o NS ignore Annotation and SA annotation added (valid) = PullSecret added

## How are existing users impacted? What migration steps/scripts do we need?
No change, the default logic of the `default` SA is still valid.
Only when users add the `alexellis.io/registry-creds.include` annotation to their ServiceAccounts will the ImagePullSecret be added.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests (No Present within current repo)
