### PR TITLE
Readme patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ To use this operator create a `ClusterPullSecret` CustomResource and apply it to
 Create a "seed" secret so that it can be referenced by the ClusterPullSecret. You can customise the name, and namespace as per your own preference.
 
 ```bash
-export UN=username
+export USERNAME=username
 export PW=mypassword
 export EMAIL=me@example.com
 
 kubectl create secret docker-registry registry-creds-secret \
   --namespace kube-system \
-  --docker-username=$UN \
+  --docker-username=$USERNAME \
   --docker-password=$PW \
   --docker-email=$EMAIL
 ```

--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ To use this operator create a `ClusterPullSecret` CustomResource and apply it to
 Create a "seed" secret so that it can be referenced by the ClusterPullSecret. You can customise the name, and namespace as per your own preference.
 
 ```bash
-export USERNAME=username
+export DOCKERHUBID=username
 export PW=mypassword
 export EMAIL=me@example.com
 
 kubectl create secret docker-registry registry-creds-secret \
   --namespace kube-system \
-  --docker-username=$USERNAME \
+  --docker-username=$DOCKERHUBID \
   --docker-password=$PW \
   --docker-email=$EMAIL
 ```
@@ -158,7 +158,7 @@ Now create a `ClusterPullSecret` YAML file, and populate the `secretRef` with th
 apiVersion: ops.alexellis.io/v1
 kind: ClusterPullSecret
 metadata:
-  name: Docker Registry
+  name: docker-registry
 spec:
   secretRef:
     name: registry-creds-secret

--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ To use this operator create a `ClusterPullSecret` CustomResource and apply it to
 Create a "seed" secret so that it can be referenced by the ClusterPullSecret. You can customise the name, and namespace as per your own preference.
 
 ```bash
-export DOCKERHUBID=username
+export UN=username
 export PW=mypassword
 export EMAIL=me@example.com
 
 kubectl create secret docker-registry registry-creds-secret \
   --namespace kube-system \
-  --docker-username=$DOCKERHUBID \
+  --docker-username=$UN \
   --docker-password=$PW \
   --docker-email=$EMAIL
 ```


### PR DESCRIPTION
## Description
ClusterPullSecret name needs to match regex in order to be applied. 

## To Reproduce
Apply to kubernetes cluster ClusterPullSecret yaml file directly from Readme.md


## Expected behavior
Its changing the name of ClusterPullSecret yaml to lowercase

 
## How Has This Been Tested?
```bash
apiVersion: ops.alexellis.io/v1
kind: ClusterPullSecret
metadata:
  name: Docker Registry
spec:
  secretRef:
    name: registry-creds-secret
    namespace: kube-system
```
Above yaml file is failing to be applied.
Changing  it to ```name: docker-registry``` solve the issue.

## How are existing users impacted? What migration steps/scripts do we need?
Not required

## Checklist:

I have:

- [] updated the documentation and/or roadmap (if required)
- [] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [] signed-off my commits with `git commit -s`
- [ ] added unit tests
