### PR TITLE
Feature/issue 21

### DIFF
--- a/.github/workflows/ci-only.yaml
+++ b/.github/workflows/ci-only.yaml
@@ -21,6 +21,9 @@ jobs:
         id: local_build
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            Version=dev
+            GitCommit=${{ github.sha }}
           outputs: "type=docker,push=false"
           platforms: linux/amd64
           tags: ghcr.io/alexellis/registry-creds:${{ github.sha }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,9 @@ jobs:
         id: local_build
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            Version=${{ steps.get_tag.outputs.TAG }}
+            GitCommit=${{ github.sha }}
           outputs: "type=registry,push=true"
           platforms: linux/amd64,linux/arm/v6,linux/arm64
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG Version
+ARG GitCommit
 
 WORKDIR /workspace
 
@@ -18,8 +20,9 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
+RUN echo flags=${Version} ${GitCommit}
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-  GO111MODULE=on go build -ldflags="-w -s" -a -o /usr/bin/controller
+  GO111MODULE=on go build -ldflags "-s -w -X main.Release=${Version} -X main.SHA=${GitCommit}" -a -o /usr/bin/controller
 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM --platform=${BUILDPLATFORM:-linux/amd64} gcr.io/distroless/static:nonroot

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 /*
 
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Apache License, Release 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
@@ -36,6 +36,8 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+	Release  string
+	SHA      string
 )
 
 func init() {
@@ -113,7 +115,7 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	setupLog.Info("starting manager")
+	setupLog.Info("starting manager with the version %s and commit %s", Release, SHA)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
## Description
version and commit information are now printed at the application startup

## Which issue # does this fix? And was it approved before you worked on it?

<!-- This is required and you must have raised an issue -->

Checklist:

- [x] Fixes issue: #21 
- [x] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

First, I edited the docker-build target within the Makefile to able to add new build args like below:
```bash
docker-build:
	@docker buildx create --use --name=multiarch --node=multiarch && \
	docker buildx build \
		--output "type=docker,push=false" \
		--build-arg Version=dev \
		--build-arg GitCommit=$(shell git rev-parse --short head) \  
		--tag ghcr.io/alexellis/registry-creds:$(TAG) \
		.
```
Then I executed that target.
```bash
$ minikube start
$ eval $(minikube docker-env)
$ TAG=a3b31a2e9510f56c4ef5b538225facf16a7f9362 make docker-build
$ make deploy
$ POD=$(kubectl get pods -n registry-creds-system --selector control-plane=registry-creds-controller -ojsonpath='{range .items[*]}{.metadata.name}')
$ kubectl logs -n registry-creds-system $POD | grep -i "starting manager"
```
![Screen Shot 2020-12-04 at 00 03 36](https://user-images.githubusercontent.com/16693043/101088077-2d038680-35c4-11eb-970d-06814d88aeae.png)

## How are existing users impacted? What migration steps/scripts do we need?

Users now are able to see which version is being run.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
