### PR TITLE
DRAFT: Bump registry-creds image version to 0.2.6 in manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -229,7 +229,7 @@ spec:
         - --enable-leader-election
         command:
         - /controller
-        image: ghcr.io/alexellis/registry-creds:0.2.5
+        image: ghcr.io/alexellis/registry-creds:0.2.6
         imagePullPolicy: IfNotPresent
         name: controller
         resources:


### PR DESCRIPTION
## Description
Bump the version of `ghcr.io/alexellis/registry-creds` in `manifest.yaml` to `0.2.6`

## Which issue # does this fix? And was it approved before you worked on it?

Fixes #24 

Checklist:

- [X] Fixes issue: #24 
- [ ] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## How Has This Been Tested?

- I validated that the behavior experienced in #24 was not happening when running `make install && make run` after cloning the repository, which told me it was likely due to an old version of the controller
- Indeed, the version of the controller specified in `manifest.yaml` was 0.2.5, when the latest version is 0.2.6.
- Updating `manifest.yaml` to reference v0.2.6 of the controller image, and using that file when running `kubectl apply` fixed the issue.


## How are existing users impacted? What migration steps/scripts do we need?

- Users that are following the README get v0.2.5 of the controller, which does not watch for service account creation
- No migration steps should be necessary

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [X] added unit tests (N/A)
