### PR TITLE
Support issue for Tanzu

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ kubectl create secret docker-registry registry-creds-secret \
   --docker-email=$EMAIL
 ```
 
-If you're not using the Docker Hub, then add `--docker-password`
+If you're not using the Docker Hub, then add `--docker-server`
 
 Now create a `ClusterPullSecret` YAML file, and populate the `secretRef` with the secret name and namespace from above.
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -78,8 +78,6 @@ rules:
   - update
   - patch
 ---
-
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -72,8 +72,6 @@ rules:
   - ""
   resources:
   - configmaps
-  resourceNames:
-  - 8bdecb1a.alexellis.io
   verbs:
   - get
   - create


### PR DESCRIPTION
## Description
Fix for permission error:
```
error initially creating leader election record: configmaps is forbidden: User "system:serviceaccount:registry-creds-system:default" cannot create resource "configmaps" in API group "" in the namespace "registry-creds-system"
```
As reported in [16#issuecomment-778186442](https://github.com/alexellis/registry-creds/issues/16#issuecomment-778186442) this is caused by the combination of `create` and `resourceNames` in role declaration: 
```yaml
rules:
- apiGroups:
  - ""
  resources:
  - configmaps
  resourceNames:
  - 8bdecb1a.alexellis.io
  verbs:
  - get
  - create
  - update
  - patch
```
> **Note:** You cannot restrict `create` or `deletecollection` requests by resourceName. For `create`, this limitation is because the object name is not known at authorization time.
> [source](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources)

**PR includes:** 
- Bugfix: Remove `Role.rules.resourceNames` from manifest.yaml. 
- Typo: Remove duplicate triple-dash in manifest.yaml
- Typo: `--docker-server` arg in Readme

## Which issue # does this fix? And was it approved before you worked on it?

<!-- This is required and you must have raised an issue -->

Checklist:

- [x] Fixes issue: #16 
- [ ] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## How Has This Been Tested?
Updated manifest deployed successfully (error gone and controller working as expected) to k8s v1.19.8 (IKS IBM Cloud) 

## How are existing users impacted? What migration steps/scripts do we need?
No impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
