### PR TITLE
CustomResourceDefinition v1 schema

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,21 +5,14 @@ metadata:
     control-plane: registry-creds-controller
   name: registry-creds-system
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
+    controller-gen.kubebuilder.io/version: v0.2.6
   creationTimestamp: null
   name: clusterpullsecrets.ops.alexellis.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.secretRef.name
-    name: SecretName
-    type: string
-  - JSONPath: .spec.secretRef.namespace
-    name: SecretNamespace
-    type: string
   group: ops.alexellis.io
   names:
     kind: ClusterPullSecret
@@ -27,34 +20,45 @@ spec:
     plural: clusterpullsecrets
     singular: clusterpullsecret
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ClusterPullSecret is the Schema for the clusterpullsecrets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ClusterPullSecretSpec defines the desired state of ClusterPullSecret
-          properties:
-            secretRef:
-              type: object
-          type: object
-        status:
-          description: ClusterPullSecretStatus defines the observed state of ClusterPullSecret
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    subresources: {}
+    additionalPrinterColumns:
+    - jsonPath: .spec.secretRef.name
+      name: SecretName
+      type: string
+    - jsonPath: .spec.secretRef.namespace
+      name: SecretNamespace
+      type: string
+    schema:
+      openAPIV3Schema:
+        description: ClusterPullSecret is the Schema for the clusterpullsecrets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterPullSecretSpec defines the desired state of ClusterPullSecret
+            properties:
+              secretRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: ClusterPullSecretStatus defines the observed state of ClusterPullSecret
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""
@@ -72,15 +76,11 @@ rules:
   - ""
   resources:
   - configmaps
-  resourceNames:
-  - 8bdecb1a.alexellis.io
   verbs:
   - get
   - create
   - update
   - patch
----
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This PR addresses two issues:
- Migration CustomResourceDefinition to "apiextensions.k8s.io/v1" schema (k8s 1.19+ warn about "apiextensions.k8s.io/v1beta1" deprecation);
- Small manifest cleanup.

Tested under 1.19.8, the improved version works for me.