### PR TITLE
Fix leader-election-role rules

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -12,3 +12,12 @@ rules:
       - create
       - update
       - patch
+  - apiGroups:
+      - coordination.k8s.io
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+    resources:
+      - leases

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -86,6 +86,15 @@ rules:
   - create
   - update
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
## Description
<!--- Outline the changes -->
Give permission to the leader-extension-role to access coordination.k8s.io/leases

## Which issue # does this fix? And was it approved before you worked on it?

<!-- This is required and you must have raised an issue -->

Checklist:

- [x] Fixes issue: #42 
- [x] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## Are you a GitHub Sponsor (Yes/No?)

Pull Requests from sponsors get prioritised and a quicker response.

Check at: https://github.com/sponsors/alexellis
- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on our production EKS cluster.


## How are existing users impacted? What migration steps/scripts do we need?
No foreseen impact.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
