### PR TITLE
fix: kubeconfig not found

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -241,3 +241,4 @@ spec:
             cpu: 100m
             memory: 45Mi
       terminationGracePeriodSeconds: 10
+      automountServiceAccountToken: true


### PR DESCRIPTION
## Description
<!--- Outline the changes -->

## Which issue # does this fix? And was it approved before you worked on it?

<!-- This is required and you must have raised an issue -->

Checklist:

- [x] Fixes issue: #44
- [ ] I waited for approval before creating this PR

Note: if the PR is for a typo, please close it and raise an issue instead.

## Are you a GitHub Sponsor (Yes/No?)

Pull Requests from sponsors get prioritised and a quicker response.

Check at: https://github.com/sponsors/alexellis
- [ ] Yes
- [x] No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Forked repo
- added `automountServiceAccountToken: true`
- used the forked repo in argocd to deploy to 3 clusters in 1.23
- checked that it fixed the error (and of course it did)

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/inlets/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
